### PR TITLE
Added Masked cloze_score and refactored to be defined in parent class

### DIFF
--- a/minicons/scorer.py
+++ b/minicons/scorer.py
@@ -435,24 +435,30 @@ class MaskedLMScorer(LMScorer):
 
         return masked_logprobs
 
-    #TODO: Adapt to handle MLMs. Hopefully should just need to add a mask token
-    # at end and grab only that token's probs from output logits
     def next_word_distribution(self, queries: List, surprisal: bool = False):
         """
         Returns the log probability distribution of the next word.
+
+        NOTE: Currently only tested for BERT derivative models
         """
-        encoded = self.encode(queries)
-        encoded = encoded.to(self.device)
-        query_ids = [
-            [j for j, i in enumerate(instance) if i != self.tokenizer.pad_token_id][-1]
-            for instance in encoded["input_ids"].tolist()
-        ]
+        modified_prompts = self.add_special_tokens([(q + self.tokenizer.mask_token) for q in queries])
 
-        logits = self.model(**encoded).logits.detach()
-        logits[:, :, self.tokenizer.pad_token_id] = float("-inf")
+        with torch.no_grad():
+            encoded = self.tokenizer(
+                modified_prompts, add_special_tokens=False, return_tensors="pt", padding=True
+            )
+            encoded = encoded.to(self.device)
 
-        logits = logits[torch.arange(len(query_ids)), query_ids]
-        logprobs = logits - logits.logsumexp(1).unsqueeze(1)
+            test = self.tokenizer(
+                [self.tokenizer.mask_token], add_special_tokens=False, return_tensors="pt", padding=True
+            )
+            test = test.to(self.device)
+
+            logits = self.model(**encoded)
+            #INFO: mask token will always be 3rd to last in BERT models. Test with non-BERT
+            presoftmax = logits.logits[torch.arange(len(queries)), -3]
+
+        logprobs = presoftmax - presoftmax.logsumexp(1).unsqueeze(1)
 
         if surprisal:
             logprobs = -1.0 * logprobs
@@ -469,20 +475,23 @@ class MaskedLMScorer(LMScorer):
         """
         Computes the cloze score for a selection of completion tokens. Input is expected to be
         a list of contexts and a 2-D list of completions, one completion list per context.
+
+        NOTE: Currently only tested for BERT derivative models
         """
-        #TODO: This should work for RoBERTa and all other BERT tokenizer LLMs. Should verify with non-BERT models
+        #INFO: This should work for RoBERTa and all other BERT tokenizer LLMs. Should verify with non-BERT models
         target_tokens = torch.stack([self.encode(t)['input_ids'][:,1] for t in targets]).squeeze().to(self.device)
 
-        if len(targets.shape) > 2:
+        if len(target_tokens.shape) > 2:
             raise NotImplementedError('Cloze score not defined for more than one token')
 
         dists = self.next_word_distribution(queries, surprisal)
-        target_probs = torch.gather(dists, 1, targets).tolist()
+        target_probs = torch.gather(dists, 1, target_tokens).tolist()
 
         if return_dist:
             return target_probs, dists.tolist()
         else:
             return target_probs
+
 
     def prepare_text(self, text: Union[str, List[str]], PLL_metric: Optional[str] = "original") -> Iterable[Any]:
         """


### PR DESCRIPTION
After implementation, it was clear that the only necessary differences between MLMScorer and CLMScorer are how the target tokens are encoded and how the next_word_distribution is defined. I defined a next_word_distribution for MLMs such that a mask token is added to the end of the contexts before adding the bos and eos tokens (for models that do so) before inferencing the probability at the mask token (this needs testing on non-BERT models, as it is unclear if all MLMs add two tokens at the end of the prompt during application of add_special_tokens).

I pulled this functionality out so that each class now implements a next_word_distribution and encode_cloze_targets function and these are now utilized by the shared LMScorer.cloze_score function.